### PR TITLE
Add rename nested folders and files with recursion and add recursive file renaming with user-defined text prefix/suffix

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -50,6 +50,29 @@
         </div>
     </div>
 
+    <div>
+        <div>
+            <h2>Rename With Numbers</h2>
+            <label for="folderPath4">Folder Path:</label>
+            <input type="text" id="folderPath4" placeholder="Select the folder path" readonly>
+            <button id="browseBtn4">Browse...</button>
+            <br>
+            <label>
+                <input type="checkbox" id="renameFoldersCheckbox">
+                Rename folders in the selected directory
+            </label>
+            <br>
+            <label>
+                <input type="checkbox" id="recursiveRenameCheckbox">
+                Rename files and folders recursively inside subdirectories
+            </label>
+            <br>
+            <input type="text" id="baseTextInput" placeholder="Base Text for Renaming">
+            <button id="renameWithNumbersBtn">Rename with Numbers</button>
+            <pre id="output4"></pre>
+        </div>
+    </div>
+
     <script src="renderer.js"></script>
 </body>
 

--- a/src/index.html
+++ b/src/index.html
@@ -35,6 +35,21 @@
         <pre id="output2"></pre>
     </div>
 
+    <div>
+        <div>
+            <h2>Add text to start or end</h2>
+            <label for="folderPath3">Folder Path:</label>
+            <input type="text" id="folderPath3" placeholder="Select the folder path" readonly>
+            <button id="browseBtn3">Browse...</button>
+            <br>
+            <input type="text" id="addTextInput" placeholder="Введите текст">
+            <input type="checkbox" id="addToStartCheckbox"> Добавить в начало
+            <input type="checkbox" id="addToEndCheckbox"> Добавить в конец
+            <button id="addTextBtn">Применить</button>
+            <pre id="output3"></pre>
+        </div>
+    </div>
+
     <script src="renderer.js"></script>
 </body>
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -39,6 +39,26 @@ document.getElementById('replaceBtn').addEventListener('click', () => {
     }
 });
 
+document.getElementById('browseBtn3').addEventListener('click', async () => {
+    const folderPath = await ipcRenderer.invoke('dialog:openFile');
+    if (folderPath && folderPath.length > 0) {
+        document.getElementById('folderPath3').value = folderPath[0];
+    }
+});
+
+document.getElementById('addTextBtn').addEventListener('click', () => {
+    const directory = document.getElementById('folderPath3').value;
+    const text = document.getElementById('addTextInput').value;
+    const addToStart = document.getElementById('addToStartCheckbox').checked;
+    const addToEnd = document.getElementById('addToEndCheckbox').checked;
+
+    if (directory && (addToStart || addToEnd)) {
+        addTextToFiles(directory, text, addToStart, addToEnd);
+    } else {
+        alert('Please select a folder and at least one checkbox.');
+    }
+});
+
 function renameFilesInFolder(folder, patternToRemove) {
     fs.readdir(folder, (err, files) => {
         if (err) {
@@ -107,6 +127,58 @@ function findAndReplace(directory, searchText, replaceText) {
                             }
                         });
                     }
+                }
+            });
+        });
+    });
+}
+
+function addTextToFiles(directory, text, addToStart, addToEnd) {
+    fs.readdir(directory, (err, files) => {
+        if (err) {
+            console.error(`Error reading directory: ${directory}`, err);
+            document.getElementById('output3').textContent = `Error reading directory: ${directory}`;
+            return;
+        }
+
+        files.forEach((file) => {
+            const oldPath = path.join(directory, file);
+
+            fs.stat(oldPath, (err, stats) => {
+                if (err) {
+                    console.error(`Error getting file stats: ${oldPath}`, err);
+                    document.getElementById('output3').textContent = `Error getting file stats: ${oldPath}`;
+                    return;
+                }
+
+                if (stats.isDirectory()) {
+                    // Если это директория, рекурсивно вызываем функцию для обработки файлов в поддиректории
+                    addTextToFiles(oldPath, text, addToStart, addToEnd);
+                } else if (stats.isFile()) {
+                    let newFileName = file;
+
+                    if (addToStart && addToEnd) {
+                        const ext = path.extname(file);
+                        const fileNameWithoutExt = path.basename(file, ext);
+                        newFileName = text + fileNameWithoutExt + text + ext;
+                    } else if (addToStart) {
+                        newFileName = text + file;
+                    } else if (addToEnd) {
+                        const ext = path.extname(file);
+                        const fileNameWithoutExt = path.basename(file, ext);
+                        newFileName = fileNameWithoutExt + text + ext;
+                    }
+
+                    const newPath = path.join(directory, newFileName);
+
+                    fs.rename(oldPath, newPath, (err) => {
+                        if (err) {
+                            console.error(`Error renaming file: ${oldPath}`, err);
+                            document.getElementById('output3').textContent += `Error renaming file: ${oldPath}\n`;
+                        } else {
+                            document.getElementById('output3').textContent += `Renamed: ${oldPath} -> ${newPath}\n`;
+                        }
+                    });
                 }
             });
         });


### PR DESCRIPTION
Add rename nested folders and files with recursion and add recursive file renaming with user-defined text prefix/suffix.

Description:

Recursive file renaming with user-defined text prefix/suffix: This is a block with several inputs and checkboxes, allowing the user to select a directory, and to all files inside which the text from another input, which the user fills in, will be added. Also, to select where to add the desired text, there are checkboxes - for the beginning and end, respectively.

Rename nested folders and files with recursion:
This is a block that allows the user to select a directory within which he can rename based on the filled input - all nested files and folders (or just files) both recursively and not.

Affected code areas:
src/index.html
src/renderer.js

Backward compatibility:
Changes should not affect existing functionality.

Additional notes:
The frontend is implemented without styles, only functionality.